### PR TITLE
@lru_cache decorator needs parameterized in Python <3.8

### DIFF
--- a/macaddr.py
+++ b/macaddr.py
@@ -43,7 +43,7 @@ class MacAddress(object):
         if len(self.chars) != 12:
             raise ValueError(f"Invalid MAC address: {macaddr}")
 
-    @lru_cache
+    @lru_cache()
     def format(
         self,
         size: Optional[int] = 2,
@@ -90,7 +90,7 @@ class MacAddress(object):
         value = sep.join("".join(islice(i_chars, size)) for _ in range(chunks))
         return value if not to_case else to_case(value)
 
-    @lru_cache
+    @lru_cache()
     def format_oui(
         self,
         size: Optional[int] = 2,


### PR DESCRIPTION
I installed this module on a system running Python 3.7, it explodes when importing:

```
Python 3.7.9 (default, Dec 14 2020, 09:16:04)
[GCC 5.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from typing import Optional
>>> exit
Use exit() or Ctrl-D (i.e. EOF) to exit
>>> import macaddr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/python3-venv/lib/python3.7/site-packages/macaddr.py", line 9, in <module>
    class MacAddress(object):
  File "/python3-venv/lib/python3.7/site-packages/macaddr.py", line 51, in MacAddress
    to_case: Optional[Callable] = None,
  File "/opt/linuxbrew/Cellar/python@3.7/3.7.9_2/lib/python3.7/functools.py", line 490, in lru_cache
    raise TypeError('Expected maxsize to be an integer or None')
TypeError: Expected maxsize to be an integer or None

```

I added () to the decorator to work around this, it seems to work in Python 3.8 this way as well.